### PR TITLE
Add version tagging job

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -179,6 +179,39 @@ jobs:
             --push --output='{{range .}}{{.Tag}}@{{.Digest}}{{end}}')
           echo "digest=$(echo $BUILD | cut -d'@' -f2)" >> $GITHUB_OUTPUT
 
+  tag-version:
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.ref == 'refs/heads/develop' && github.event_name == 'push'
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Compute version
+        id: ver
+        run: echo "version=$(scripts/version.sh version)" >> $GITHUB_OUTPUT
+      - name: Export version metadata
+        run: |
+          scripts/version.sh print > version.txt
+          cat version.txt >> "$GITHUB_STEP_SUMMARY"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: version-info
+          path: version.txt
+      - name: Tag commit
+        run: |
+          TAG=${{ steps.ver.outputs.version }}
+          if git rev-parse "refs/tags/$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists. Skipping."
+          else
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git tag "$TAG"
+            git push origin "$TAG"
+          fi
+
 # -------------------------------------------------------------------------
 # 5. Semantic‑release (tag + changelog) – main branch only
 # -------------------------------------------------------------------------

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -8,28 +8,37 @@ set -euo pipefail
 # Function to get version from git
 get_version() {
     local version=""
-    
+    local suffix=""
+
+    if [ -n "${CI:-}" ]; then
+        suffix="-ci"
+    else
+        suffix="-dev"
+    fi
+
     # Check if we're in a git repository
     if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-        echo "dev"
+        echo "dev${suffix}"
         return
     fi
-    
+
     # Try to get version from git tags
     if git describe --tags --exact-match >/dev/null 2>&1; then
         # We're on a tagged commit
         version=$(git describe --tags --exact-match)
+        suffix=""
     elif git describe --tags >/dev/null 2>&1; then
         # We're ahead of the latest tag
-        version=$(git describe --tags --always --dirty)
+        version="$(git describe --tags --always --dirty)${suffix}"
     else
         # No tags found, use commit hash
         version=$(git rev-parse --short HEAD)
         if [ -n "$(git status --porcelain)" ]; then
             version="${version}-dirty"
         fi
+        version="${version}${suffix}"
     fi
-    
+
     echo "${version}"
 }
 


### PR DESCRIPTION
## Summary
- add tag-version job for develop
- add -ci/-dev suffix logic to version script

## Testing
- `make test` *(fails: context cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_686a50babf30833282507a8ec3f40281